### PR TITLE
Load top song match using duckduckgo

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -19,8 +19,7 @@ const open = () => {
     let artistName = status.track.artist_resource.name
     let query = encodeURIComponent(`${artistName} - ${trackName}`)
 
-    let url = 'https://genius.com/search?q='
-
-    shell.openExternal(`${url}${query}`)
+    let url = 'https://duckduckgo.com/?q=site:https://genius.com ${query} !'
+    shell.openExternal(url)
   })
 }


### PR DESCRIPTION
This uses [duckduckgo bangs](https://duckduckgo.com/bang) to load the first result of a search of [genius.com](https://genius.com).

The url format is changed to:
```
https://duckduckgo.com/?q=site:https://genius.com ${query} !
```